### PR TITLE
Hotfix release 0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ Each row of ``NIRSChannelsTable`` represents a specific source and detector pair
 
 ## Installation
 
+To install from PyPI use pip:
+
+```
+$ pip install ndx-nirs
+```
+
 To install after cloning the extension repo from github, execute the following from the root of the repo:
 
 ```
@@ -99,9 +105,6 @@ For development purposes, it might be useful to install in editable mode:
 ```
 $ pip install -e .
 ```
-
-Note: a version of the ndx-nirs package will be released on PyPI before the extension is submitted to the NDX Catalog.
-
 
 ## Usage
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,10 +22,10 @@ copyright = "2021, Sumner L Norman,Darin Erat Sleiter,José Ribeiro"
 author = "Sumner L Norman,Darin Erat Sleiter,José Ribeiro"
 
 # The short X.Y version
-version = "0.1.0"
+version = "0.1.1"
 
 # The full version, including alpha/beta/rc tags
-release = "0.1.0"
+release = "0.1.1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,7 +1,17 @@
 Release Notes
 =============
 
-v0.1.0:
+v0.1.1 (April 23, 2021):
+-------
+
+Hotfix release.
+
+Fixes:
+   - constrain ``hdmf`` dependency to version 2.4.0 until the just-released 2.5.0 can be tested
+   - update documentation to indicate how to install ``ndx-nirs`` from PyPI
+   - constrain wheel to be python 3 only
+
+v0.1.0 (April 22, 2021):
 -------
 
 Initial release version of the extension which includes support for several standard NIRS datatypes.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-pynwb>=1.4.0
+pynwb==1.4.0
+hdmf==2.4.0
 hdmf_docutils

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [wheel]
-universal = 1
+universal = 0
 
 [flake8]
 max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ except Exception:
 
 setup_args = {
     "name": "ndx-nirs",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "An NWB extension for storing Near-Infrared Spectroscopy (NIRS) data",
     "long_description": readme,
     "long_description_content_type": readme_type,
@@ -31,7 +31,7 @@ setup_args = {
     "url": "https://github.com/agencyenterprise/ndx-nirs",
     "license": "BSD 3-Clause",
     "python_requires": ">=3.6",
-    "install_requires": ["pynwb>=1.4.0"],
+    "install_requires": ["hdmf==2.4.0", "pynwb==1.4.0"],
     "packages": find_packages("src/pynwb"),
     "package_dir": {"": "src/pynwb"},
     "package_data": {

--- a/spec/ndx-nirs.namespace.yaml
+++ b/spec/ndx-nirs.namespace.yaml
@@ -25,4 +25,4 @@ namespaces:
     - Data
     - ElementIdentifiers
   - source: ndx-nirs.extensions.yaml
-  version: 0.1.0
+  version: 0.1.1

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -17,7 +17,7 @@ def main():
     ns_builder = NWBNamespaceBuilder(
         doc="""An NWB extension for storing Near-Infrared Spectroscopy (NIRS) data""",
         name="""ndx-nirs""",
-        version="""0.1.0""",
+        version="""0.1.1""",
         author=list(
             map(
                 str.strip,


### PR DESCRIPTION
* Fix #16
* constrain hdmf==2.4.0
* set wheel to be py3-only
* update documentation to include instructions for installation via pip