### PR TITLE
Update hdmf dependency to 2.5 and improve dependency specification

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pynwb==1.4.0
-hdmf==2.4.0
+pynwb~=1.4
+hdmf~=2.5
 hdmf_docutils

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ setup_args = {
     "author_email": "sumner@ae.studio,darin@ae.studio,jose@ae.studio",
     "url": "https://github.com/agencyenterprise/ndx-nirs",
     "license": "BSD 3-Clause",
-    "python_requires": ">=3.6",
-    "install_requires": ["hdmf==2.4.0", "pynwb==1.4.0"],
+    "python_requires": "~=3.6",
+    "install_requires": ["hdmf~=2.5", "pynwb~=1.4"],
     "packages": find_packages("src/pynwb"),
     "package_dir": {"": "src/pynwb"},
     "package_data": {


### PR DESCRIPTION
* Fix #18
* All unit tests pass using hdmf version 2.5.5
* Improve dependency specification to use "compatible release" specification notation