### PR TITLE
Update python versions and dependency versions hdmf and pynwb

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,10 @@
-pynwb>=1.5.1,<2
-hdmf>=2.5.6,<3
+pynwb>=2.0.0,<3
+hdmf>=3.1.1,<4
 
 # dependencies for building documentation
 hdmf_docutils
 sphinx~=4.0
+
+# dev requirements
+pytest
+flake8

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ setup_args = {
     "author_email": "sumner@ae.studio,darin@ae.studio,jose@ae.studio",
     "url": "https://github.com/agencyenterprise/ndx-nirs",
     "license": "BSD 3-Clause",
-    "python_requires": "~=3.6",
-    "install_requires": ["hdmf>=2.5.6,<3", "pynwb>=1.5.1,<2"],
+    "python_requires": ">=3.7,<3.11",
+    "install_requires": ["hdmf>=3.1.1,<4", "pynwb>=2.0.0,<3"],
     "packages": find_packages("src/pynwb"),
     "package_dir": {"": "src/pynwb"},
     "package_data": {
@@ -41,6 +41,11 @@ setup_args = {
         ]
     },
     "classifiers": [
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Intended Audience :: Developers",
         "Intended Audience :: Science/Research",
     ],


### PR DESCRIPTION
Fixes #23 

* update hdmf and pynwb dependency versions to the newest versions
* update python version requirements to match 3.7-3.10
* all tests pass with the newest versions of hdmf and pynwb with python 3.7, 3.8, 3.9, and 3.10

note: pynwb doesn't explicitly specify supported python versions, and only mentions python versions in the classifications as far as I can tell. The classifications include 3.7, 3.8, and 3.9 but not 3.10. However, since hdmf supports 3.10 and all tests passed using 3.10, it seems reasonable to assume 3.10 works (at least until we get a failure report)