### PR TITLE
Specify that optode positions are measured in meters

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ Each row of ``NIRSChannelsTable`` represents a specific source and detector pair
 
 1. ``NIRSSourcesTable`` stores rows for each optical source of a NIRS device. ``NIRSSourcesTable`` includes:
     - ``label`` - the label of the source
-    - ``x``, ``y``, and ``z`` - the coordinates of the optical source (``z`` is optional)
+    - ``x``, ``y``, and ``z`` - the coordinates in meters of the optical source (``z`` is optional)
 
 2. ``NIRSDetectorsTable`` stores rows for each of the optical detectors of a NIRS device. ``NIRSDetectorsTable`` includes:
     - ``label`` - the label of the detector
-    - ``x``, ``y``, and ``z`` - the coordinates of the optical detector (``z`` is optional)
+    - ``x``, ``y``, and ``z`` - the coordinates in meters of the optical detector (``z`` is optional)
 
 3. ``NIRSChannelsTable`` stores rows for each physiological channel, which is defined by source-detector pairs, where sources & detectors are referenced via ``NIRSSourcesTable`` and ``NIRSDetectorsTable``. ``NIRSChannelsTable`` includes:
     - ``label`` - the label of the channel

--- a/docs/source/description.rst
+++ b/docs/source/description.rst
@@ -25,11 +25,11 @@ Extension Spec
 --------------
 1. ``NIRSSourcesTable`` stores rows for each optical source of a NIRS device. ``NIRSSourcesTable`` includes:
     - ``label`` - the label of the source
-    - ``x``, ``y``, and ``z`` - the coordinates of the optical source (``z`` is optional)
+    - ``x``, ``y``, and ``z`` - the coordinates in meters of the optical source (``z`` is optional) 
 
 2. ``NIRSDetectorsTable`` stores rows for each of the optical detectors of a NIRS device. ``NIRSDetectorsTable`` includes:
     - ``label`` - the label of the detector
-    - ``x``, ``y``, and ``z`` - the coordinates of the optical detector (``z`` is optional)
+    - ``x``, ``y``, and ``z`` - the coordinates in meters of the optical detector (``z`` is optional)
 
 3. ``NIRSChannelsTable`` stores rows for each physiological channel, which is defined by source-detector pairs, where sources & detectors are referenced via ``NIRSSourcesTable`` and ``NIRSDetectorsTable``. ``NIRSChannelsTable`` includes:
     - ``label`` - the label of the channel

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,6 +1,15 @@
 Release Notes
 =============
 
+Upcoming:
+-------
+
+Improvements:
+  - update ``pywnb`` and ``hdmf`` dependencies to use the newest versions
+  - update supported python versions to include 3.7, 3.8, 3.9, and 3.10
+  - specified that all source and detector positions should be measured in meters and updated documentation accordingly
+
+
 v0.2.0 (June 1, 2021):
 -------
 

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -8,9 +8,6 @@ from pynwb.spec import (
     NWBAttributeSpec,
 )
 
-# TODO: import the following spec classes as needed
-# from pynwb.spec import NWBDatasetSpec, NWBLinkSpec, NWBDtypeSpec, NWBRefSpec
-
 
 def main():
     # these arguments were auto-generated from your cookiecutter inputs
@@ -32,7 +29,7 @@ def main():
         ),
     )
 
-    # TODO: specify the neurodata_types that are used by the extension as well
+    # specify the neurodata_types that are used by the extension as well
     # as in which namespace they are found
     # this is similar to specifying the Python modules that need to be imported
     # to use your new data types
@@ -51,10 +48,9 @@ def main():
     ns_builder.include_type("ElementIdentifiers", namespace="hdmf-common")
     ns_builder.include_type("Device", namespace="core")
 
-    # TODO: define your new data types
+    # define your new data types
     # see https://pynwb.readthedocs.io/en/latest/extensions.html#extending-nwb
     # for more information
-
     nirs_sources = NWBGroupSpec(
         neurodata_type_def="NIRSSourcesTable",
         neurodata_type_inc="DynamicTable",
@@ -70,21 +66,21 @@ def main():
             ),
             NWBDatasetSpec(
                 name="x",
-                doc="The x coordinate of the optical source",
+                doc="The x coordinate in meters of the optical source",
                 dtype="float",
                 shape=(None,),
                 neurodata_type_inc="VectorData",
             ),
             NWBDatasetSpec(
                 name="y",
-                doc="The y coordinate of the optical source",
+                doc="The y coordinate in meters of the optical source",
                 dtype="float",
                 shape=(None,),
                 neurodata_type_inc="VectorData",
             ),
             NWBDatasetSpec(
                 name="z",
-                doc="The z coordinate of the optical source",
+                doc="The z coordinate in meters of the optical source",
                 dtype="float",
                 shape=(None,),
                 neurodata_type_inc="VectorData",
@@ -108,21 +104,21 @@ def main():
             ),
             NWBDatasetSpec(
                 name="x",
-                doc="The x coordinate of the optical detector",
+                doc="The x coordinate in meters of the optical detector",
                 dtype="float",
                 shape=(None,),
                 neurodata_type_inc="VectorData",
             ),
             NWBDatasetSpec(
                 name="y",
-                doc="The y coordinate of the optical detector",
+                doc="The y coordinate in meters of the optical detector",
                 dtype="float",
                 shape=(None,),
                 neurodata_type_inc="VectorData",
             ),
             NWBDatasetSpec(
                 name="z",
-                doc="The z coordinate of the optical detector",
+                doc="The z coordinate in meters of the optical detector",
                 dtype="float",
                 shape=(None,),
                 neurodata_type_inc="VectorData",
@@ -301,7 +297,7 @@ def main():
         ],
     )
 
-    # TODO: add all of your new data types to this list
+    # all new data types defined in this module
     new_data_types = [
         nirs_sources,
         nirs_detectors,


### PR DESCRIPTION
* Fix #22
* The UOM is specified in the source and detector table x, y, and z column descriptions
* Documentation has also been updated appropriately